### PR TITLE
Minor updates for Python 3.12 deprecation with collections.Iterable and shapely.enable

### DIFF
--- a/pluq/inbase.py
+++ b/pluq/inbase.py
@@ -19,7 +19,7 @@ from sklearn.neighbors import KernelDensity
 from sklearn.model_selection import GridSearchCV
 
 import fiona
-from shapely import speedups
+# from shapely import speedups
 from shapely.prepared import prep
 from shapely.ops import transform
 from shapely.geometry import MultiPolygon, Polygon, Point, mapping
@@ -29,8 +29,8 @@ from pluq.base import Correlation, ProteinSeq, CSExperiment
 
 
 # Use shapely speed-ups if they are available.
-if speedups.available:
-    speedups.enable()
+# if speedups.available:
+#     speedups.enable()
 
 
 # PDF class with methods for extracting parameters

--- a/pluq/pluqin.py
+++ b/pluq/pluqin.py
@@ -194,7 +194,7 @@ def main(resonance_set, experiment_name='c', seq=None, level=95,
         raise ValueError(mesg)
 
     # A little input validation.
-    if isinstance(resonance_set[0], collections.Iterable):
+    if isinstance(resonance_set[0], collections.abc.Iterable):
         peak_dims = len(resonance_set[0])
     else:
         peak_dims = 1


### PR DESCRIPTION
Updated code for python3.12:

1. collections.Iterable has been totally moved to collections.abc.Iterable with python3.12 (works fine for earlier versions but with a deprecation warning)
2. shapely.enable is not necessary anymore and currently, a warning appears constantly: Commented out